### PR TITLE
Print exceptions with stacktrace

### DIFF
--- a/bootstrap/src/helpers.py
+++ b/bootstrap/src/helpers.py
@@ -1,3 +1,4 @@
+import traceback
 from functools import wraps
 
 from sanic import response
@@ -21,3 +22,7 @@ def get_model(model: BaseRequest):
 
         return wrapper
     return decorator
+
+
+def prettify_exc(exception: Exception) -> str:
+    return ''.join(traceback.format_exception(None, exception, exception.__traceback__))

--- a/bootstrap/src/middlewares.py
+++ b/bootstrap/src/middlewares.py
@@ -10,7 +10,7 @@ from sanic import Sanic
 from sanic.exceptions import SanicException
 
 from . import errors
-from .helpers import json_response
+from .helpers import json_response, prettify_exc
 from .log import req_id, req_id_generator
 
 req_start_time: ContextVar[int] = ContextVar('req_start_time', default=None)
@@ -93,5 +93,6 @@ def init_middlewares(app: Sanic, config):
     @app.exception(Exception)
     def internal_error_handler(request, exception: Exception):
         # Log the exception and return an internal server error
-        logger.error(f'Unexpected exception: {str(exception)}')
+        logger.error(f'Unexpected exception:\n'
+                     f'{prettify_exc(exception)}')
         return json_response(errors.InternalError().to_dict(), errors.InternalError.code)


### PR DESCRIPTION
Now we also print stack trace in the logs, and not only the message, so

```
Unexpected exception:
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
ZeroDivisionError: integer division or modulo by zero
```

instead of 
```Unexpected exception: 'integer division or modulo by zero'```