### PR TITLE
More descriptive HTTP response codes + Swagger 2.0 to OpenAPI 3.0

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1,402 +1,406 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
+  title: "Kin Python Microservice"
   description: "Micro service to invoke common kin stuff using the kin-python-sdk."
   version: "2.0.0"
-  title: "Kin Python Microservice"
   license:
-    name: "MIT"
-    url: "https://opensource.org/licenses/MIT"
-schemes:
-- "https"
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - description: Do not expose an instance of this server directly to the public
+    url: http://localhost:8000
+security: []
 paths:
-
   /pay:
     post:
       tags:
-      - "Endpoints:"
-      summary: "Send KIN to an address"
-      operationId: "sendKin"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        description: "Payment Request object"
-        required: true
-        schema:
-          $ref: "#/definitions/PaymentRequest"
+        - Endpoints
+      summary: Send KIN to an address
+      operationId: sendKin
       responses:
-        200:
-          description: "Successful request"
-          schema:
-            $ref: "#/definitions/TransactionResponse"
-        400:
-          $ref: "#/definitions/LowBalanceError"
-        404:
-          $ref: "#/definitions/DestinationDoesNotExistError"
-
+        "200":
+          $ref: "#/components/responses/SuccessfulTransaction"
+        "400":
+          $ref: "#/components/responses/LowBalanceError"
+        "404":
+          description: Receiver address does not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationDoesNotExistError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PaymentRequest"
+        description: Payment Request object
+        required: true
   /create:
     post:
       tags:
-      - "Endpoints:"
-      summary: "Create an account on the blockchain"
-      operationId: "createAccount"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        description: "Creation request object"
-        required: true
-        schema:
-          $ref: "#/definitions/CreationRequest"
+        - Endpoints
+      summary: Create an account on the blockchain
+      operationId: createAccount
       responses:
-        200:
-          description: "Successful request"
-          schema:
-            $ref: "#/definitions/TransactionResponse"
-        400:
-          $ref: "#/definitions/LowBalanceError"
-        409:
-          $ref: "#/definitions/DestinationExistsError"
-
+        "200":
+          $ref: "#/components/responses/SuccessfulTransaction"
+        "400":
+          $ref: "#/components/responses/LowBalanceError"
+        "409":
+          description: Receiver address already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DestinationExistsError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreationRequest"
+        description: Creation request object
+        required: true
   /balance/{address}:
     get:
       tags:
-      - "Endpoints:"
-      summary: "Get the KIN balance of an account"
-      operationId: "getBalance"
-      produces:
-      - "application/json"
+        - Endpoints
+      summary: Get the KIN balance of an account
+      operationId: getBalance
       parameters:
         - in: path
           name: address
           required: true
-          type: string
           description: The public address of the account to query
-      responses:
-        200:
-          description: "Successful request"
           schema:
-            $ref: "#/definitions/BalanceResponse"
-        400:
-          $ref: "#/definitions/AccountNotFoundError"
-
+            type: string
+      responses:
+        "200":
+          description: Successful request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BalanceResponse"
+        "400":
+          description: Account address not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountNotFoundError"
   /payment/{tx_hash}:
     get:
       tags:
-      - "Endpoints:"
-      summary: "Get info about a kin payment"
-      operationId: "getPayment"
-      produces:
-      - "application/json"
+        - Endpoints
+      summary: Get info about a kin payment
+      operationId: getPayment
       parameters:
         - in: path
           name: tx_hash
           required: true
-          type: string
           description: The hash of the payment transaction
-      responses:
-        200:
-          description: "Successful request"
           schema:
-            $ref: "#/definitions/PaymentInfoResponse"
-        404:
-          $ref: "#/definitions/TransactionNotFoundError"
-        400:
-          $ref: "#/definitions/InvalidTransactionError"
-
-
-
+            type: string
+      responses:
+        "200":
+          description: Successful request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaymentInfoResponse"
+        "400":
+          description: Invalid transaction
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvalidTransactionError"
+        "404":
+          description: Transaction not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TransactionNotFoundError"
   /whitelist:
     post:
       tags:
-      - "Endpoints:"
-      summary: "Whitelist a transaction"
-      operationId: "whitelist"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        description: "Whitelist request object"
-        required: true
-        schema:
-          $ref: "#/definitions/WhitelistRequest"
+        - Endpoints
+      summary: Whitelist a transaction
+      operationId: whitelist
       responses:
-        200:
-          description: "Successful request"
-          schema:
-            $ref: "#/definitions/WhitelistResponse"
-        400:
-          $ref: "#/definitions/CantDecodeTransactionError"
-
-
+        "200":
+          description: Successful request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WhitelistResponse"
+        "400":
+          description: Can't decode the transaction envelope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CantDecodeTransactionError"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WhitelistRequest"
+        description: Whitelist request object
+        required: true
   /status:
     get:
       tags:
-      - "Endpoints:"
-      summary: "Get the current config/status of the service (Use as healthcheck)"
-      operationId: "status"
-      produces:
-      - "application/json"
+        - Endpoints
+      summary: Get the current config/status of the service (Use as health check)
+      operationId: status
       responses:
-        200:
-          description: "Successful request"
+        "200":
+          description: Successful request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResponse"
+
+components:
+  schemas:
+    CreationRequest:
+      type: object
+      required:
+        - destination
+        - starting_balance
+        - memo
+      properties:
+        destination:
+          type: string
+          example: GCJEHC2UOSIDPPIHJ2SH3B2ZL5XBB7KYK2M6OHXZTUW4NI2NEVVFVDLD
+        starting_balance:
+          type: number
+          example: 5
+        memo:
+          type: string
+          example: null
+    PaymentRequest:
+      type: object
+      required:
+        - destination
+        - amount
+        - memo
+      properties:
+        destination:
+          type: string
+          example: GCJEHC2UOSIDPPIHJ2SH3B2ZL5XBB7KYK2M6OHXZTUW4NI2NEVVFVDLD
+        amount:
+          type: number
+          example: 130
+        memo:
+          type: string
+          example: Order-123
+    WhitelistRequest:
+      type: object
+      properties:
+        envelope:
+          type: string
+          example: >-
+            AAAAACQpNXQ4NCGx5OeZCkDJTzqAdXYY4qedTmyUwcE2c02wAAAAAAANfdwAAAADAAAAAAAAAAEAAAAcMS1sNjhiLVQwQzJuUUZwOU1VeE5tRDc3RE5wcQAAAAEAAAAAAAAAAQAAAADSTsz/bFP7AezxTQVxZrzaHXErPrT49yakAlKWKxMSEQAAAAAAAAAAAJiWgAAAAAAAAAACNnNNsAAAAEDymQhlExH6oyNIVzxLDhTdQrEu567QmRguIsJ/nnCd2UsMxphe88NYAtcPsRGtLDeq/T3dVO6TuUp+BCTClIIHMU/hGAAAAEAbmxZQ81NFZAcpYHJgCctxeeWdKanlK92JoqX58ui0wAoaSb1DtpHMCdBQE/UGulz29zLC8A4Mgk/nq/rmqlMI
+        network_id:
+          type: string
+          example: Kin Mainnet ; December 2018
+
+    BalanceResponse:
+      type: object
+      properties:
+        balance:
+          type: number
+          example: 154.5
+    PaymentInfoResponse:
+      type: object
+      properties:
+        source:
+          type: string
+          example: GDG57ST5LAJNFKSZHSSX7ME3ET6JTZQHDQF5LX7OM2GJNRSE2VJ2OSKB
+        destination:
+          type: string
+          example: GA3YVWB2N3RJCDNAGRD6WC6QIDYC5VP6KRBSG3EDL4UFQKMJBVMAET6Y
+        amount:
+          type: number
+          example: 15
+        memo:
+          type: string
+          example: Hello
+        timestamp:
+          type: integer
+          example: 1547545819
+    StatusResponse:
+      type: object
+      properties:
+        service_version:
+          type: string
+          example: 1.4.2
+        horizon:
+          type: string
+          example: http://horizon.kinfederation.com
+        app_id:
+          type: string
+          example: rc43
+        public_address:
+          type: string
+          example: GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX
+        balance:
+          type: number
+          example: 179875
+        channels:
+          type: object
+          properties:
+            free_channels:
+              type: number
+              example: 17
+            non_free_channels:
+              type: number
+              example: 3
+            total_channels:
+              type: number
+              example: 20
+    TransactionResponse:
+      type: object
+      properties:
+        tx_id:
+          type: string
+          example: ae9b957a857c843cd8d921820f9695daa5aa00f51f1665ff925999ab0ccd54bd
+    WhitelistResponse:
+      type: object
+      properties:
+        tx_envelope:
+          type: string
+          example: >-
+            AAAAACQpNXQ4NCGx5OeZCkDJTzqAdXYY4qedTmyUwcE2c02wAAAAAAANfdwAAAADAAAAAAAAAAEAAAAcMS1sNjhiLVQwQzJuUUZwOU1VeE5tRDc3RE5wcQAAAAEAAAAAAAAAAQAAAADSTsz/bFP7AezxTQVxZrzaHXErPrT49yakAlKWKxMSEQAAAAAAAAAAAJiWgAAAAAAAAAACNnNNsAAAAEDymQhlExH6oyNIVzxLDhTdQrEu567QmRguIsJ/nnCd2UsMxphe88NYAtcPsRGtLDeq/T3dVO6TuUp+BCTClIIHMU/hGAAAAEAbmxZQ81NFZAcpYHJgCctxeeWdKanlK92JoqX58ui0wAoaSb1DtpHMCdBQE/UGulz29zLC8A4Mgk/nq/rmqlMI
+
+    AccountNotFoundError:
+      description: Account not found
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4041
+        message:
+          type: string
+          example: Account 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' was not found
+    CantDecodeTransactionError:
+      description: Cant decode the transaction envelope
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4005
+        message:
+          type: string
+          example: The service is unable to decode the received transaction envelope
+    DestinationDoesNotExistError:
+      description: Destination doesn't exist
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4002
+        message:
+          type: string
+          example: Destination 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' does not exist
+    DestinationExistsError:
+      description: Destination already exists
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4009
+        message:
+          type: string
+          example: Destination 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' already exists
+    ExtraParamError:
+      description: Extra parameters
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4007
+        message:
+          type: string
+          example: The parameter '{extra_param}' was not expected for this requests body
+    InternalError:
+      description: Internal server error
+      type: object
+      properties:
+        code:
+          type: number
+          example: 500
+        message:
+          type: string
+          example: Internal server error
+    InvalidBodyError:
+      description: Invalid body
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4008
+        message:
+          type: string
+          example: The received body was not a valid json
+    InvalidParamError:
+      description: Invalid parameter
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4001
+        message:
+          type: string
+          example: Destination 'qwert' is not a valid public address
+    InvalidTransactionError:
+      description: Invalid transaction found
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4004
+        message:
+          type: string
+          example: The specified transaction was not a valid kin payment transaction
+    LowBalanceError:
+      description: Low balance
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4003
+        message:
+          type: string
+          example: The account does not have enough kin to perform this operation
+    MissingParamError:
+      description: Missing parameters
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4006
+        message:
+          type: string
+          example: The parameter '{missing_param}' was missing from the requests body
+    TransactionNotFoundError:
+      description: Transaction not found
+      type: object
+      properties:
+        code:
+          type: number
+          example: 4041
+        message:
+          type: string
+          example: Transaction 'ae9b957a857c843cd8d921820f9695daa5aa00f51f1665ff925999ab0ccd54bd' was not found
+
+  responses:
+    LowBalanceError:
+      description: Sender does not have enough kin
+      content:
+        application/json:
           schema:
-            $ref: "#/definitions/StatusResponse"
-
-
-definitions:
-
-  PaymentRequest:
-    type: object
-    required: [destination, amount, memo]
-    properties:
-      destination:
-        type: string
-        example: GCJEHC2UOSIDPPIHJ2SH3B2ZL5XBB7KYK2M6OHXZTUW4NI2NEVVFVDLD
-      amount:
-        type: number
-        example: 130
-      memo:
-        type: string
-        example: "Order-123"
-
-  CreationRequest:
-    type: object
-    required: [destination, starting_balance, memo]
-    properties:
-      destination:
-        type: string
-        example: GCJEHC2UOSIDPPIHJ2SH3B2ZL5XBB7KYK2M6OHXZTUW4NI2NEVVFVDLD
-      starting_balance:
-        type: number
-        example: 5
-      memo:
-        type: string
-        example: null
-
-  TransactionResponse:
-    type: object
-    properties:
-      tx_id:
-        type: string
-        example: ae9b957a857c843cd8d921820f9695daa5aa00f51f1665ff925999ab0ccd54bd
-
-  BalanceResponse:
-    type: object
-    properties:
-      balance:
-        type: number
-        example: 154.5
-
-  PaymentInfoResponse:
-    type: object
-    properties:
-      source:
-        type: string
-        example: "GDG57ST5LAJNFKSZHSSX7ME3ET6JTZQHDQF5LX7OM2GJNRSE2VJ2OSKB"
-      destination:
-        type: string
-        example: "GA3YVWB2N3RJCDNAGRD6WC6QIDYC5VP6KRBSG3EDL4UFQKMJBVMAET6Y"
-      amount:
-        type: number
-        example: 15
-      memo:
-        type: string
-        example: "Hello"
-      timestamp:
-        type: integer
-        example: 1547545819
-
-  WhitelistRequest:
-    type: object
-    properties:
-      envelope:
-        type: string
-        example: AAAAACQpNXQ4NCGx5OeZCkDJTzqAdXYY4qedTmyUwcE2c02wAAAAAAANfdwAAAADAAAAAAAAAAEAAAAcMS1sNjhiLVQwQzJuUUZwOU1VeE5tRDc3RE5wcQAAAAEAAAAAAAAAAQAAAADSTsz/bFP7AezxTQVxZrzaHXErPrT49yakAlKWKxMSEQAAAAAAAAAAAJiWgAAAAAAAAAACNnNNsAAAAEDymQhlExH6oyNIVzxLDhTdQrEu567QmRguIsJ/nnCd2UsMxphe88NYAtcPsRGtLDeq/T3dVO6TuUp+BCTClIIHMU/hGAAAAEAbmxZQ81NFZAcpYHJgCctxeeWdKanlK92JoqX58ui0wAoaSb1DtpHMCdBQE/UGulz29zLC8A4Mgk/nq/rmqlMI
-      network_id:
-        type: string
-        example: "Kin Mainnet ; December 2018"
-
-  WhitelistResponse:
-    type: object
-    properties:
-      tx_envelope:
-        type: string
-        example: AAAAACQpNXQ4NCGx5OeZCkDJTzqAdXYY4qedTmyUwcE2c02wAAAAAAANfdwAAAADAAAAAAAAAAEAAAAcMS1sNjhiLVQwQzJuUUZwOU1VeE5tRDc3RE5wcQAAAAEAAAAAAAAAAQAAAADSTsz/bFP7AezxTQVxZrzaHXErPrT49yakAlKWKxMSEQAAAAAAAAAAAJiWgAAAAAAAAAACNnNNsAAAAEDymQhlExH6oyNIVzxLDhTdQrEu567QmRguIsJ/nnCd2UsMxphe88NYAtcPsRGtLDeq/T3dVO6TuUp+BCTClIIHMU/hGAAAAEAbmxZQ81NFZAcpYHJgCctxeeWdKanlK92JoqX58ui0wAoaSb1DtpHMCdBQE/UGulz29zLC8A4Mgk/nq/rmqlMI
-
-  StatusResponse:
-    type: object
-    properties:
-      service_version:
-        type: string
-        example: "1.4.2"
-      horizon:
-        type: string
-        example: "http://horizon.kinfederation.com"
-      app_id:
-        type: string
-        example: "rc43"
-      public_address:
-        type: string
-        example: "GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX"
-      balance:
-        type: number
-        example: 179875
-      channels:
-        type: object
-        properties:
-          free_channels:
-            type: number
-            example: 17
-          non_free_channels:
-            type: number
-            example: 3
-          total_channels:
-            type: number
-            example: 20
-
-# Global Errors
-
-  InvalidParamError:
-    description: "Invalid parameter"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4001
-      message:
-        type: string
-        example: "Destination 'qwert' is not a valid public address"
-
-  InternalError:
-    description: "Internal server error"
-    type: object
-    properties:
-      code:
-        type: number
-        example : 500
-      message:
-        type: string
-        example: "Internal server error"
-
-  MissingParamError:
-    description: "Missing parameters"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4006
-      message:
-        type: string
-        example: "The parameter '{missing_param}' was missing from the requests body"
-
-  ExtraParamError:
-    description: "Extra parameters"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4007
-      message:
-        type: string
-        example: "The parameter '{extra_param}' was not expected for this requests body"
-
-  InvalidBodyError:
-    description: "Invalid body"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4008
-      message:
-        type: string
-        example: "The received body was not a valid json"
-
-
-# Specific Errors
-
-  DestinationDoesNotExistError:
-    description: "Destination doesn't exist"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4002
-      message:
-        type: string
-        example: "Destination 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' does not exist"
-
-  DestinationExistsError:
-    description: "Destination already exists"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4009
-      message:
-        type: string
-        example: "Destination 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' already exists"
-
-  LowBalanceError:
-    description: "Low balance"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4003
-      message:
-        type: string
-        example: "The account does not have enough kin to perform this operation"
-
-  AccountNotFoundError:
-    description: "Account not found"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4041
-      message:
-        type: string
-        example: "Account 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' was not found"
-
-  TransactionNotFoundError:
-    description: "Transaction not found"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4041
-      message:
-        type: string
-        example: "Transaction 'ae9b957a857c843cd8d921820f9695daa5aa00f51f1665ff925999ab0ccd54bd' was not found"
-
-  InvalidTransactionError:
-    description: "Invalid transaction found"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4004
-      message:
-        type: string
-        example: "The specified transaction was not a valid kin payment transaction"
-
-  CantDecodeTransactionError:
-    description: "Cant decode the transaction envelope"
-    type: object
-    properties:
-      code:
-        type: number
-        example: 4005
-      message:
-        type: string
-        example: "The service is unable to decode the received transaction envelope"
+            $ref: "#/components/schemas/LowBalanceError"
+    SuccessfulTransaction:
+      description: Successful request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TransactionResponse"

--- a/api.yaml
+++ b/api.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: "Micro service to invoke common kin stuff using the kin-python-sdk."
-  version: "1.0.0"
+  version: "2.0.0"
   title: "Kin Python Microservice"
   license:
     name: "MIT"
@@ -26,18 +26,17 @@ paths:
         description: "Payment Request object"
         required: true
         schema:
-          $ref: '#/definitions/PaymentRequest'
+          $ref: "#/definitions/PaymentRequest"
       responses:
         200:
-          description: 'Successfull request'
+          description: "Successful request"
           schema:
-            $ref: '#/definitions/TransactionResponse'
-        # Swagger doesn't support same http code for several responses, so i add a slash to bypass it
+            $ref: "#/definitions/TransactionResponse"
         400:
-          $ref: '#/definitions/DestinationDoesNotExistError'
-        400/:
-          $ref: '#/definitions/LowBalanceError'
-          
+          $ref: "#/definitions/LowBalanceError"
+        404:
+          $ref: "#/definitions/DestinationDoesNotExistError"
+
   /create:
     post:
       tags:
@@ -54,17 +53,17 @@ paths:
         description: "Creation request object"
         required: true
         schema:
-          $ref: '#/definitions/CreationRequest'
+          $ref: "#/definitions/CreationRequest"
       responses:
         200:
-          description: 'Successfull request'
+          description: "Successful request"
           schema:
-            $ref: '#/definitions/TransactionResponse'
+            $ref: "#/definitions/TransactionResponse"
         400:
-          $ref: '#/definitions/LowBalanceError'
-        400/:
-          $ref: '#/definitions/DestinationExistsError'
-          
+          $ref: "#/definitions/LowBalanceError"
+        409:
+          $ref: "#/definitions/DestinationExistsError"
+
   /balance/{address}:
     get:
       tags:
@@ -81,12 +80,12 @@ paths:
           description: The public address of the account to query
       responses:
         200:
-          description: 'Successfull request'
+          description: "Successful request"
           schema:
-            $ref: '#/definitions/BalanceResponse'
+            $ref: "#/definitions/BalanceResponse"
         400:
-          $ref: '#/definitions/AccountNotFoundError'
-          
+          $ref: "#/definitions/AccountNotFoundError"
+
   /payment/{tx_hash}:
     get:
       tags:
@@ -103,16 +102,16 @@ paths:
           description: The hash of the payment transaction
       responses:
         200:
-          description: 'Successfull request'
+          description: "Successful request"
           schema:
-            $ref: '#/definitions/PaymentInfoResponse'
+            $ref: "#/definitions/PaymentInfoResponse"
         404:
-          $ref: '#/definitions/TransactionNotFoundError'
+          $ref: "#/definitions/TransactionNotFoundError"
         400:
-          $ref: '#/definitions/InvalidTransactionError'
-        
-          
-          
+          $ref: "#/definitions/InvalidTransactionError"
+
+
+
   /whitelist:
     post:
       tags:
@@ -129,16 +128,16 @@ paths:
         description: "Whitelist request object"
         required: true
         schema:
-          $ref: '#/definitions/WhitelistRequest'
+          $ref: "#/definitions/WhitelistRequest"
       responses:
         200:
-          description: 'Successfull request'
+          description: "Successful request"
           schema:
-            $ref: '#/definitions/WhitelistResponse'
+            $ref: "#/definitions/WhitelistResponse"
         400:
-          $ref: '#/definitions/CantDecodeTransactionError'
-        
-          
+          $ref: "#/definitions/CantDecodeTransactionError"
+
+
   /status:
     get:
       tags:
@@ -149,11 +148,11 @@ paths:
       - "application/json"
       responses:
         200:
-          description: "Successfull request"
+          description: "Successful request"
           schema:
-            $ref: '#/definitions/StatusResponse'
+            $ref: "#/definitions/StatusResponse"
 
-          
+
 definitions:
 
   PaymentRequest:
@@ -169,7 +168,7 @@ definitions:
       memo:
         type: string
         example: "Order-123"
-        
+
   CreationRequest:
     type: object
     required: [destination, starting_balance, memo]
@@ -183,21 +182,21 @@ definitions:
       memo:
         type: string
         example: null
-        
+
   TransactionResponse:
     type: object
     properties:
       tx_id:
         type: string
         example: ae9b957a857c843cd8d921820f9695daa5aa00f51f1665ff925999ab0ccd54bd
-        
+
   BalanceResponse:
     type: object
     properties:
       balance:
         type: number
         example: 154.5
-        
+
   PaymentInfoResponse:
     type: object
     properties:
@@ -216,7 +215,7 @@ definitions:
       timestamp:
         type: integer
         example: 1547545819
-        
+
   WhitelistRequest:
     type: object
     properties:
@@ -233,7 +232,7 @@ definitions:
       tx_envelope:
         type: string
         example: AAAAACQpNXQ4NCGx5OeZCkDJTzqAdXYY4qedTmyUwcE2c02wAAAAAAANfdwAAAADAAAAAAAAAAEAAAAcMS1sNjhiLVQwQzJuUUZwOU1VeE5tRDc3RE5wcQAAAAEAAAAAAAAAAQAAAADSTsz/bFP7AezxTQVxZrzaHXErPrT49yakAlKWKxMSEQAAAAAAAAAAAJiWgAAAAAAAAAACNnNNsAAAAEDymQhlExH6oyNIVzxLDhTdQrEu567QmRguIsJ/nnCd2UsMxphe88NYAtcPsRGtLDeq/T3dVO6TuUp+BCTClIIHMU/hGAAAAEAbmxZQ81NFZAcpYHJgCctxeeWdKanlK92JoqX58ui0wAoaSb1DtpHMCdBQE/UGulz29zLC8A4Mgk/nq/rmqlMI
-        
+
   StatusResponse:
     type: object
     properties:
@@ -264,11 +263,11 @@ definitions:
           total_channels:
             type: number
             example: 20
-            
+
 # Global Errors
 
   InvalidParamError:
-    description: 'Invalid parameter'
+    description: "Invalid parameter"
     type: object
     properties:
       code:
@@ -277,9 +276,9 @@ definitions:
       message:
         type: string
         example: "Destination 'qwert' is not a valid public address"
-        
+
   InternalError:
-    description: 'Internal server error'
+    description: "Internal server error"
     type: object
     properties:
       code:
@@ -288,9 +287,9 @@ definitions:
       message:
         type: string
         example: "Internal server error"
-        
+
   MissingParamError:
-    description: 'Missing parameters'
+    description: "Missing parameters"
     type: object
     properties:
       code:
@@ -299,9 +298,9 @@ definitions:
       message:
         type: string
         example: "The parameter '{missing_param}' was missing from the requests body"
-        
+
   ExtraParamError:
-    description: 'Extra parameters'
+    description: "Extra parameters"
     type: object
     properties:
       code:
@@ -312,7 +311,7 @@ definitions:
         example: "The parameter '{extra_param}' was not expected for this requests body"
 
   InvalidBodyError:
-    description: 'Invalid body'
+    description: "Invalid body"
     type: object
     properties:
       code:
@@ -320,8 +319,8 @@ definitions:
         example: 4008
       message:
         type: string
-        example: 'The received body was not a valid json'
-  
+        example: "The received body was not a valid json"
+
 
 # Specific Errors
 
@@ -346,9 +345,9 @@ definitions:
       message:
         type: string
         example: "Destination 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' already exists"
-        
+
   LowBalanceError:
-    description: 'Low balance'
+    description: "Low balance"
     type: object
     properties:
       code:
@@ -357,9 +356,9 @@ definitions:
       message:
         type: string
         example: "The account does not have enough kin to perform this operation"
-        
+
   AccountNotFoundError:
-    description: 'Account not found'
+    description: "Account not found"
     type: object
     properties:
       code:
@@ -368,9 +367,9 @@ definitions:
       message:
         type: string
         example: "Account 'GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX' was not found"
-        
+
   TransactionNotFoundError:
-    description: 'Transaction not found'
+    description: "Transaction not found"
     type: object
     properties:
       code:
@@ -379,9 +378,9 @@ definitions:
       message:
         type: string
         example: "Transaction 'ae9b957a857c843cd8d921820f9695daa5aa00f51f1665ff925999ab0ccd54bd' was not found"
-        
+
   InvalidTransactionError:
-    description: 'Invalid transaction found'
+    description: "Invalid transaction found"
     type: object
     properties:
       code:
@@ -390,9 +389,9 @@ definitions:
       message:
         type: string
         example: "The specified transaction was not a valid kin payment transaction"
-        
+
   CantDecodeTransactionError:
-    description: 'Cant decode the transaction envelope'
+    description: "Cant decode the transaction envelope"
     type: object
     properties:
       code:
@@ -401,4 +400,3 @@ definitions:
       message:
         type: string
         example: "The service is unable to decode the received transaction envelope"
-        

--- a/bootstrap/salted-hostname-entrypoint
+++ b/bootstrap/salted-hostname-entrypoint
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# As a convenience for where host names will be persistent across reboots
+# running this script as the container's `CMD` will suffix the passed
+# salt (if it exists) with the container's hostname, before starting
+# the server, creating a unique but persistent salt per hostname.
+
+[ ! -z ${CHANNEL_SALT} ] && export CHANNEL_SALT=${CHANNEL_SALT}-$(hostname)
+
+pipenv run python main.py

--- a/bootstrap/src/errors.py
+++ b/bootstrap/src/errors.py
@@ -61,7 +61,7 @@ class DestinationDoesNotExistError(BootstrapError):
 class LowBalanceError(BootstrapError):
     def __init__(self):
         self.code = 4003
-        self.http_code = 500
+        self.http_code = 400
         message = f"The account does not have enough kin to perform this operation"
         super(LowBalanceError, self).__init__(message)
 

--- a/bootstrap/src/errors.py
+++ b/bootstrap/src/errors.py
@@ -4,7 +4,7 @@ from pydantic import ValidationError, ExtraError, MissingError, PydanticTypeErro
 
 class InternalError(Exception):
     """Internal error to use when when an unexpected exception happens"""
-    error = 'Internal server error'
+    error = "Internal server error"
     code = 500
 
     def to_dict(self):
@@ -20,7 +20,7 @@ class BootstrapError(Exception):
         return {'code': self.code, 'message': self.error}
 
     def __str__(self):
-        return f'{type(self).__name__}: {self.error}'
+        return f"{type(self).__name__}: {self.error}"
 
     def __repr__(self):
         return self.__str__()
@@ -53,7 +53,7 @@ class ExtraParamError(BootstrapError):
 class DestinationDoesNotExistError(BootstrapError):
     def __init__(self, destination):
         self.code = 4002
-        self.http_code = 400
+        self.http_code = 404
         message = f"Destination '{destination}' does not exist"
         super(DestinationDoesNotExistError, self).__init__(message)
 
@@ -61,8 +61,8 @@ class DestinationDoesNotExistError(BootstrapError):
 class LowBalanceError(BootstrapError):
     def __init__(self):
         self.code = 4003
-        self.http_code = 400
-        message = f'The account does not have enough kin to perform this operation'
+        self.http_code = 500
+        message = f"The account does not have enough kin to perform this operation"
         super(LowBalanceError, self).__init__(message)
 
 
@@ -86,7 +86,7 @@ class InvalidTransactionError(BootstrapError):
     def __init__(self):
         self.code = 4004
         self.http_code = 400
-        message = f'The specified transaction was not a valid kin payment transaction'
+        message = f"The specified transaction was not a valid kin payment transaction"
         super(InvalidTransactionError, self).__init__(message)
 
 
@@ -94,14 +94,14 @@ class CantDecodeTransactionError(BootstrapError):
     def __init__(self):
         self.code = 4005
         self.http_code = 400
-        message = f'The service was unable to decode the received transaction envelope'
+        message = f"The service was unable to decode the received transaction envelope"
         super(CantDecodeTransactionError, self).__init__(message)
 
 
 class DestinationExistsError(BootstrapError):
     def __init__(self, destination):
         self.code = 4009
-        self.http_code = 400
+        self.http_code = 409
         message = f"Destination '{destination}' already exists"
         super(DestinationExistsError, self).__init__(message)
 
@@ -110,7 +110,7 @@ class InvalidBodyError(BootstrapError):
     def __init__(self):
         self.code = 4008
         self.http_code = 400
-        message = f'The received body was not a valid json'
+        message = f"The received body was not a valid json"
         super(InvalidBodyError, self).__init__(message)
 
 
@@ -131,6 +131,6 @@ def translate_validation_error(val_error: ValidationError) -> BootstrapError:
     if isinstance(first_error, MissingError):
         return MissingParamError(faulty_arg)
     if isinstance(first_error, PydanticTypeError):
-        return InvalidParamError(f'Parameter {faulty_arg}, is invalid: {first_error}')
+        return InvalidParamError(f"Parameter {faulty_arg}, is invalid: {first_error}")
 
     raise val_error  # If we can't translate the error, raise it like that.


### PR DESCRIPTION
  - DestinationDoesNotExist error changed from 400 (Bad Request) to 404
(Not Found)
  - DestinationExistsError changed from 400 (Bad Request) to 409
(Conflict)

NOTE: Because of the change in response codes (and therefore the API
contract with clients), the major version number has increased from 1 to
2 (new version number is 2.0.0)

NOTE: Incidentally, the 2 changes above also remove the need for
redefining the 400 response code multiple times in api.yaml, preventing
the validation errors when browsing the spec online

  - Fixed typo: "Successfull" -> "Successful"
  - Consistent double quoting of value strings in api.yaml
  - Consistent double quoting of format strings in
bootstrap.src/errors.py