### PR TITLE
New configuration setting: "WHITELISTED"

### DIFF
--- a/bootstrap/src/config.py
+++ b/bootstrap/src/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     """
 
     SEED: str = 'SCOMIY6IHXNIL6ZFTBBYDLU65VONYWI3Y6EN4IDWDP2IIYTCYZBCCE6C'
+    WHITELISTED: bool = False
     HORIZON_ENDPOINT: str = kin_config.HORIZON_URI_TEST
     NETWORK_PASSPHRASE: str = kin_config.HORIZON_PASSPHRASE_TEST
     APP_ID: str = kin_config.ANON_APP_ID

--- a/bootstrap/src/middlewares.py
+++ b/bootstrap/src/middlewares.py
@@ -63,7 +63,11 @@ def init_middlewares(app: Sanic, config):
     @app.listener('before_server_start')
     async def setup_kin_with_network(app, loop):
         """This method is separate from "setup_kin" cause it makes network calls that we want to mock"""
-        app.minimum_fee = await app.kin_client.get_minimum_fee()
+        if config.WHITELISTED is True:
+          app.minimum_fee = 0
+        else:
+          app.minimum_fee = await app.kin_client.get_minimum_fee()
+        logger.debug(f'config.WHITELISTED was {config.WHITELISTED}, setting transaction fee to: {app.minimum_fee}')
 
         # Create channels
         if config.CHANNEL_COUNT > 0:


### PR DESCRIPTION
Implemented a new `WHITELISTED` config/environment variable.

Setting it to any of: `True`, `true`, `'True'`, `'true'`, `'1'`, `1` (and probably some others, but not just a 'truthy' string) will enable it, which sets `app.minimum_fee` to 0).

The default behavior (or explicitly disabling this new setting) remains as it was (always attempts to send the result of 'get_minimum_fee' as run on startup as the fee.

As a result of being based on my fork's master which already includes the changes open in PR #14 
